### PR TITLE
Mavericks main

### DIFF
--- a/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/LefuScaleModule.kt
+++ b/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/LefuScaleModule.kt
@@ -1,8 +1,8 @@
 package expo.modules.lefuscale
 
 import expo.modules.kotlin.modules.Module
-import com.lefu.ppbase.PPDeviceModel
 import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.kotlin.Promise
 import expo.modules.lefuscale.device.LefuScaleService
 import kotlinx.coroutines.*
 import android.util.Log
@@ -34,19 +34,67 @@ class LefuScaleModule : Module() {
       lefuService?.startScan()
     }
 
-    AsyncFunction("connectToDevice") { mac: String? ->
-      mac?.let {
-        lefuService?.connectToDevice(it)
-      }
+    AsyncFunction("connectToDevice") { mac: String ->
+      lefuService?.connectToDevice(mac)
     }
 
-    AsyncFunction("disconnect") {
-      lefuService?.disconnect()
-      sendEvent("onBleStateChange", mapOf("state" to "CustomPPBWorkSearchDeviceDisconnected"))
+    AsyncFunction("disconnect") { promise: Promise ->
+      CoroutineScope(Dispatchers.Default).launch {
+        try {
+          val success = lefuService?.disconnect() ?: false
+          promise.resolve(success)
+        } catch (e: Exception) {
+          promise.reject("DISCONNECT_ERROR", "Failed to disconnect from scale", e)
+        }
+      }
     }
 
     AsyncFunction("stopScan") {
       lefuService?.stopScan()
+    }
+
+    AsyncFunction("toZeroKitchenScale") { promise: Promise ->
+      CoroutineScope(Dispatchers.Default).launch {
+        try {
+          val success = lefuService?.toZeroKitchenScale() ?: false
+          promise.resolve(success)
+        } catch (e: Exception) {
+          promise.resolve(false)
+        }
+      }
+    }
+
+    AsyncFunction("changeKitchenScaleUnit") { unit: String, promise: Promise ->
+      CoroutineScope(Dispatchers.Default).launch {
+        try {
+          val result = lefuService?.changeKitchenScaleUnit(unit) ?: false
+          promise.resolve(result)
+        } catch (e: Exception) {
+          promise.resolve(false)
+        }
+      }
+    }
+
+    AsyncFunction("sendSyncTime") { promise: Promise ->
+      CoroutineScope(Dispatchers.Default).launch {
+        try {
+          val success = lefuService?.sendSyncTime() ?: false
+          promise.resolve(success)
+        } catch (e: Exception) {
+          promise.resolve(false)
+        }
+      }
+    }
+
+    AsyncFunction("switchBuzzer") { isOn: Boolean, promise: Promise ->
+      CoroutineScope(Dispatchers.Default).launch {
+        try {
+          val result = lefuService?.switchBuzzer(isOn) ?: false
+          promise.resolve(result)
+        } catch (e: Exception) {
+          promise.resolve(false)
+        }
+      }
     }
 
     OnDestroy {

--- a/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/AbstractDevice.kt
+++ b/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/AbstractDevice.kt
@@ -17,13 +17,13 @@ abstract class AbstractDevice {
     var onBroadcastReceived: ((String) -> Unit)? = null
 
     /**
-     * Initialize the device with the provided device model.
+     * Initialize the device with the provided device model.     
      * Sets up the device controller and other necessary state before connecting.
      */
     abstract fun setup(device: PPDeviceModel)
 
     /**
-     * Attempts to connect to the device.
+     * Attempts to connect to the device.     
      * @return `true` if the connection was successful, `false` otherwise.
      */
     abstract fun connect(device: PPDeviceModel): Boolean
@@ -33,11 +33,31 @@ abstract class AbstractDevice {
      */
     abstract suspend fun disconnect()
 
+    /**
+     * Tare the scale to zero.   
+     * @return `true` if the operation was successful, `false` otherwise.
+     */
     abstract suspend fun toZeroKitchenScale(): Boolean
 
+    /**
+     * Change the scale unit type.
+     * 
+     * @param unit: The unit type to change to.  
+     * @return `true` if the operation was successful, `false` otherwise.
+     */
     abstract suspend fun changeKitchenScaleUnit(unit: String): Boolean
 
+    /**
+     * Send sync time to the scale.    
+     * @return `true` if the operation was successful, `false` otherwise.
+     */
     abstract suspend fun sendSyncTime(): Boolean
 
+    /**
+     * Switch the buzzer on or off.   
+     *   
+     * @param isOn: Whether to turn the buzzer on or off.     
+     * @return `true` if the operation was successful, `false` otherwise.    
+     */
     abstract suspend fun switchBuzzer(isOn: Boolean): Boolean
 }

--- a/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/AbstractDevice.kt
+++ b/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/AbstractDevice.kt
@@ -14,47 +14,22 @@ abstract class AbstractDevice {
     var bleStateInterface: PPBleStateInterface? = null
 
     var onDataChange: ((Map<String, Any>) -> Unit)? = null
-    
     var onBroadcastReceived: ((String) -> Unit)? = null
 
-    open fun setDevice(device: PPDeviceModel) {
-        this.lefuDevice = device
-    }
+    /**
+     * Initialize the device with the provided device model.
+     * Sets up the device controller and other necessary state before connecting.
+     */
+    abstract fun setup(device: PPDeviceModel)
 
     /**
      * Attempts to connect to the device.
      * @return `true` if the connection was successful, `false` otherwise.
      */
-    abstract fun connect(): Boolean
+    abstract fun connect(device: PPDeviceModel): Boolean
 
     /**
-     * Adds a listener to receive bluetooth status of the device.
+     * Disconnect and clean up the device.
      */
-    abstract fun addBleStatusListener(listener: PPBleStateInterface)
-
-    /**
-     * Register listener to receive data from the device.
-     */
-    abstract fun startDataListener()
-
-    /**
-     * Unregister listener to receive data from the device.
-     */
-    abstract fun removeDataListener()
-
-    /**
-     * Gets the current status of the device.
-     * @return `true` if the device is discoverable, `false` otherwise.
-     */
-    abstract fun getDeviceStatus(): Boolean
-
-    /**
-     * Initialize the auto reconnect mechanism of the device
-     */
-    abstract fun autoReconnect()
-
-    /**
-     * Disconnect from the device.
-     */
-    abstract fun disconnect()
+    abstract suspend fun disconnect()
 }

--- a/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/AbstractDevice.kt
+++ b/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/AbstractDevice.kt
@@ -32,4 +32,12 @@ abstract class AbstractDevice {
      * Disconnect and clean up the device.
      */
     abstract suspend fun disconnect()
+
+    abstract suspend fun toZeroKitchenScale(): Boolean
+
+    abstract suspend fun changeKitchenScaleUnit(unit: String): Boolean
+
+    abstract suspend fun sendSyncTime(): Boolean
+
+    abstract suspend fun switchBuzzer(isOn: Boolean): Boolean
 }

--- a/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/DeviceControllerFactory.kt
+++ b/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/DeviceControllerFactory.kt
@@ -2,6 +2,7 @@ package expo.modules.lefuscale.device
 
 import android.content.Context
 import expo.modules.lefuscale.device.impl.HamburgerDeviceImpl
+// import expo.modules.lefuscale.device.impl.FishDeviceImpl
 import com.lefu.ppbase.PPScaleDefine.PPDevicePeripheralType
 
 /**

--- a/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/DeviceControllerFactory.kt
+++ b/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/DeviceControllerFactory.kt
@@ -2,7 +2,7 @@ package expo.modules.lefuscale.device
 
 import android.content.Context
 import expo.modules.lefuscale.device.impl.HamburgerDeviceImpl
-// import expo.modules.lefuscale.device.impl.FishDeviceImpl
+import expo.modules.lefuscale.device.impl.FishDeviceImpl
 import com.lefu.ppbase.PPScaleDefine.PPDevicePeripheralType
 
 /**
@@ -21,7 +21,7 @@ class DeviceControllerFactory {
         fun getInstance(deviceType: PPDevicePeripheralType): AbstractDevice {
             return when (deviceType) {
                 PPDevicePeripheralType.PeripheralHamburger -> HamburgerDeviceImpl()
-                // PPDevicePeripheralType.PeripheralFish -> FishDeviceImpl()
+                PPDevicePeripheralType.PeripheralFish -> FishDeviceImpl()
 
                 // TODO: Add cases for other supported device types as they are implemented.
                 else -> throw IllegalArgumentException("Unsupported device type: $deviceType")

--- a/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/LefuScaleService.kt
+++ b/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/LefuScaleService.kt
@@ -117,7 +117,7 @@ class LefuScaleService {
      * Connection status is reported via the [onConnectionStateChange] callback.
      * @param device The [PPDeviceModel] of the device to connect to.
      */
-    fun connectToDevice(deviceMac: String) {
+    fun connectToDevice(deviceMac: String): Boolean {
         stopScan()
         Log.d(TAG, "Attempting to connect to $deviceMac")
 
@@ -129,7 +129,7 @@ class LefuScaleService {
             )
             Log.e(TAG, errorMsg)
             onConnectError?.invoke(eventData)
-            return
+            return false
         }
 
         val device = discoveredDevices.find { it.deviceMac == deviceMac }
@@ -142,7 +142,7 @@ class LefuScaleService {
             )
             Log.e(TAG, errorMsg)
             onConnectError?.invoke(eventData)
-            return
+            return false
         }
 
         try {
@@ -159,13 +159,16 @@ class LefuScaleService {
             this.deviceImpl?.autoReconnect()
 
             Log.d(TAG, "Connection process started for ${device.deviceMac}")
+
+            return true
         } catch (e: IllegalArgumentException) {
             Log.e(TAG, "Unsupported device type: ${device.getDevicePeripheralType()}", e)
             val eventData = mapOf(
                 "state" to "connectToDevice",
-                "errorMessage" to "Unsupported Device"
+                "errorMessage" to "Unsupported device type: ${device.getDevicePeripheralType()}"
             )
             onConnectError?.invoke(eventData)
+            return false
         }
     }
 

--- a/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/LefuScaleService.kt
+++ b/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/LefuScaleService.kt
@@ -8,7 +8,6 @@ import com.peng.ppscale.business.ble.listener.PPSearchDeviceInfoInterface
 import com.peng.ppscale.business.state.PPBleWorkState
 import com.peng.ppscale.search.PPSearchManager
 import com.lefu.ppbase.PPDeviceModel
-import expo.modules.lefuscale.device.impl.FishDeviceImpl
 
 /**
  * A service class to manage interactions with the Lefu Scale SDK.
@@ -83,7 +82,7 @@ class LefuScaleService {
 
         discoveredDevices.clear() // Clears the list of discovered devices
         searchManager?.startSearchDeviceList(
-            6000,
+            30000,
             PPSearchDeviceInfoInterface { device, _ ->
                 Log.d(TAG, "Device Found: ${device.deviceName} - ${device.deviceMac} (${device.getDevicePeripheralType().name})")
                 device?.let {
@@ -200,22 +199,18 @@ class LefuScaleService {
     }
 
     suspend fun toZeroKitchenScale(): Boolean {
-        val fishDevice = deviceImpl as? FishDeviceImpl
-        return fishDevice?.toZeroKitchenScale() ?: false
+        return deviceImpl?.toZeroKitchenScale() ?: false
     }
 
     suspend fun changeKitchenScaleUnit(unit: String): Boolean {
-        val fishDevice = deviceImpl as? FishDeviceImpl
-        return fishDevice?.changeKitchenScaleUnit(unit) ?: false
+        return deviceImpl?.changeKitchenScaleUnit(unit) ?: false
     }
 
     suspend fun sendSyncTime(): Boolean {
-        val fishDevice = deviceImpl as? FishDeviceImpl
-        return fishDevice?.sendSyncTime() ?: false
+        return deviceImpl?.sendSyncTime() ?: false
     }
 
     suspend fun switchBuzzer(isOn: Boolean): Boolean {
-        val fishDevice = deviceImpl as? FishDeviceImpl
-        return fishDevice?.switchBuzzer(isOn) ?: false
+        return deviceImpl?.switchBuzzer(isOn) ?: false
     }
 }

--- a/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/impl/FishDeviceImpl.kt
+++ b/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/impl/FishDeviceImpl.kt
@@ -28,7 +28,6 @@ class FishDeviceImpl : AbstractDevice() {
     private val dataChangeListener = object : FoodScaleDataChangeListener() {
         override fun processData(foodScaleGeneral: LFFoodScaleGeneral?, deviceModel: PPDeviceModel) {
             foodScaleGeneral?.let {
-                onBroadcastReceived!!.invoke("CustomPPBWorkSearchDeviceFound")
                 FoodScaleUtils.handleScaleData(it, isStable = false) { payload ->
                     onDataChange!!.invoke(payload)
                 }
@@ -38,7 +37,6 @@ class FishDeviceImpl : AbstractDevice() {
 
         override fun lockedData(foodScaleGeneral: LFFoodScaleGeneral?, deviceModel: PPDeviceModel) {
             foodScaleGeneral?.let {
-                onBroadcastReceived!!.invoke("CustomPPBWorkSearchDeviceFound")
                 FoodScaleUtils.handleScaleData(it, isStable = true) { payload ->
                     onDataChange!!.invoke(payload)
                 }
@@ -78,7 +76,7 @@ class FishDeviceImpl : AbstractDevice() {
                             disconnectMonitorJob?.cancel()
                             disconnectMonitorJob = null
                         }
-    
+
                         PPBleWorkState.PPBleWorkStateDisconnected,
                         PPBleWorkState.PPBleWorkStateConnectFailed -> {
                             onBroadcastReceived?.invoke("CustomPPBWorkSearchNotFound")
@@ -110,7 +108,7 @@ class FishDeviceImpl : AbstractDevice() {
         this.disconnectMonitorJob = CoroutineScope(Dispatchers.Default).launch {
             while (this@FishDeviceImpl.isActive) {
                 val elapsed = System.currentTimeMillis() - FishController.lastConnectTime
-                if (elapsed > timeout) {
+                if (elapsed > timeout && this@FishDeviceImpl.lefuDevice != null) {
                     connect(this@FishDeviceImpl.lefuDevice!!)
                 }
                 delay(1000)

--- a/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/impl/FishDeviceImpl.kt
+++ b/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/impl/FishDeviceImpl.kt
@@ -119,12 +119,12 @@ class FishDeviceImpl : AbstractDevice() {
     }
     
 
-    public suspend fun toZeroKitchenScale(): Boolean {
+    override suspend fun toZeroKitchenScale(): Boolean {
         return awaitScaleResultCallback("Zeroing scale") { callback ->
             FishController.toZeroKitchenScale(callback) }
         }
 
-    public suspend fun changeKitchenScaleUnit(unit: String): Boolean {
+    override suspend fun changeKitchenScaleUnit(unit: String): Boolean {
         val ppUnit = FoodScaleUnit.fromUserInput(unit).toPPUnitType()
 
         if (ppUnit == null) {
@@ -137,15 +137,15 @@ class FishDeviceImpl : AbstractDevice() {
             FishController.changeKitchenScaleUnit(ppUnit, callback) }
     }
 
-    public suspend fun sendSyncTime(): Boolean {
+    override suspend fun sendSyncTime(): Boolean {
         return awaitScaleResultCallback("Sync time") { callback ->
             FishController.sendSyncTime(callback) }
-        }
+    }
 
-    public suspend fun switchBuzzer(isOn: Boolean): Boolean {
+    override suspend fun switchBuzzer(isOn: Boolean): Boolean {
         return awaitScaleResultCallback("Switching buzzer") { callback ->
             FishController.switchBuzzer(isOn, callback) }
-        }
+    }
 
     override suspend fun disconnect() {
         FishController.stopSeach()

--- a/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/impl/FishDeviceImpl.kt
+++ b/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/impl/FishDeviceImpl.kt
@@ -1,0 +1,158 @@
+package expo.modules.lefuscale.device.impl
+
+import java.util.concurrent.atomic.AtomicLong
+import expo.modules.lefuscale.device.AbstractDevice
+import expo.modules.lefuscale.device.utils.FoodScaleUtils
+import expo.modules.lefuscale.device.utils.FoodScaleUnit
+import com.lefu.ppbase.PPDeviceModel
+import com.peng.ppscale.device.PeripheralFish.PPBlutoothPeripheralFishController
+import com.peng.ppscale.business.ble.listener.FoodScaleDataChangeListener
+import com.peng.ppscale.business.ble.listener.PPBleStateInterface
+import com.peng.ppscale.business.state.PPBleWorkState
+import com.peng.ppscale.vo.LFFoodScaleGeneral
+import android.util.Log
+import kotlinx.coroutines.*
+import com.lefu.ppbase.vo.PPUnitType;
+import com.peng.ppscale.business.ble.listener.PPBleSendResultCallBack;
+import com.peng.ppscale.vo.PPScaleSendState;
+import awaitScaleResultCallback
+
+class FishDeviceImpl : AbstractDevice() {
+    private val TAG = "LefuScaleService: FishDevice"
+    private val timeout = 4_000L
+    private var disconnectMonitorJob: Job? = null
+    private var isActive = false
+
+    private val FishController = PPBlutoothPeripheralFishController()
+
+    private val dataChangeListener = object : FoodScaleDataChangeListener() {
+        override fun processData(foodScaleGeneral: LFFoodScaleGeneral?, deviceModel: PPDeviceModel) {
+            foodScaleGeneral?.let {
+                onBroadcastReceived!!.invoke("CustomPPBWorkSearchDeviceFound")
+                FoodScaleUtils.handleScaleData(it, isStable = false) { payload ->
+                    onDataChange!!.invoke(payload)
+                }
+                FishController.lastConnectTime = System.currentTimeMillis()
+            }
+        }
+
+        override fun lockedData(foodScaleGeneral: LFFoodScaleGeneral?, deviceModel: PPDeviceModel) {
+            foodScaleGeneral?.let {
+                onBroadcastReceived!!.invoke("CustomPPBWorkSearchDeviceFound")
+                FoodScaleUtils.handleScaleData(it, isStable = true) { payload ->
+                    onDataChange!!.invoke(payload)
+                }
+                FishController.lastConnectTime = System.currentTimeMillis()
+            }
+        }
+    }
+
+    override fun setup(device: PPDeviceModel) {
+        this.lefuDevice = device
+        FishController.registDataChangeListener(dataChangeListener)
+    }
+
+    /**
+     * Attempts to connect to the device by starting a BLE scan.
+     * Note: The actual connection is asynchronous. This method initiates the process.
+     * @return `true` if the scan was started successfully, `false` otherwise.
+     */
+    override fun connect(device: PPDeviceModel): Boolean {
+        Log.d(TAG, "Connecting to lefuscale ${device.deviceMac}")
+    
+        FishController.startConnect(
+            device,
+            object : PPBleStateInterface() {
+                override fun monitorBluetoothWorkState(
+                    state: PPBleWorkState?,
+                    deviceModel: PPDeviceModel?
+                ) {
+                    when (state) {
+                        PPBleWorkState.PPBleWorkStateConnected,
+                        PPBleWorkState.PPBleWorkStateWritable -> {
+                            onBroadcastReceived?.invoke("CustomPPBWorkSearchDeviceFound")
+                            FishController.lastConnectTime = System.currentTimeMillis()
+                            Log.d(TAG, "Successfully connected to LefuScale!")
+                            // Only sets isActive to true if successfully connected and found
+                            this@FishDeviceImpl.isActive = true
+                            disconnectMonitorJob?.cancel()
+                            disconnectMonitorJob = null
+                        }
+    
+                        PPBleWorkState.PPBleWorkStateDisconnected,
+                        PPBleWorkState.PPBleWorkStateConnectFailed -> {
+                            onBroadcastReceived?.invoke("CustomPPBWorkSearchNotFound")
+                            // Attempts to reconnect
+                            Log.d(TAG, "Attemping to reconnect...")
+                            autoReconnect()
+                        }
+    
+                        else -> {
+                            // Optional: handle other states or do nothing
+                        }
+                    }
+    
+                    Log.d(TAG, "BLE state changed: $state for ${deviceModel?.deviceName}")
+                }
+            }
+        )
+
+        return true
+    }
+    
+
+    /** 
+     * Function will execute on a background thread checking the 
+     * last update from lefuScale after the defined timeout and if scale is connected
+     */ 
+    private fun autoReconnect() {
+        this.disconnectMonitorJob?.cancel()
+        this.disconnectMonitorJob = CoroutineScope(Dispatchers.Default).launch {
+            while (this@FishDeviceImpl.isActive) {
+                val elapsed = System.currentTimeMillis() - FishController.lastConnectTime
+                if (elapsed > timeout) {
+                    connect(this@FishDeviceImpl.lefuDevice!!)
+                }
+                delay(1000)
+            }
+        }
+    }
+    
+
+    public suspend fun toZeroKitchenScale(): Boolean {
+        return awaitScaleResultCallback("Zeroing scale") { callback ->
+            FishController.toZeroKitchenScale(callback) }
+        }
+
+    public suspend fun changeKitchenScaleUnit(unit: String): Boolean {
+        val ppUnit = FoodScaleUnit.fromUserInput(unit).toPPUnitType()
+
+        if (ppUnit == null) {
+            throw IllegalArgumentException("Invalid unit: $unit")
+        }
+
+        Log.d(TAG, "Updating lefuscale unit to $unit, ppUnit: $ppUnit")
+
+        return awaitScaleResultCallback("Change unit") { callback ->
+            FishController.changeKitchenScaleUnit(ppUnit, callback) }
+    }
+
+    public suspend fun sendSyncTime(): Boolean {
+        return awaitScaleResultCallback("Sync time") { callback ->
+            FishController.sendSyncTime(callback) }
+        }
+
+    public suspend fun switchBuzzer(isOn: Boolean): Boolean {
+        return awaitScaleResultCallback("Switching buzzer") { callback ->
+            FishController.switchBuzzer(isOn, callback) }
+        }
+
+    override suspend fun disconnect() {
+        FishController.stopSeach()
+        FishController.disConnect()
+        this.isActive = false
+        disconnectMonitorJob?.cancel()
+        disconnectMonitorJob = null
+        this.lefuDevice = null
+    }
+}

--- a/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/impl/HamburgerDeviceImpl.kt
+++ b/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/impl/HamburgerDeviceImpl.kt
@@ -89,6 +89,22 @@ class HamburgerDeviceImpl : AbstractDevice() {
         return true
     }
 
+    override suspend fun toZeroKitchenScale(): Boolean {
+        throw IllegalArgumentException("Unsupported device type: ${this.lefuDevice?.deviceName}")
+    }
+
+    override suspend fun changeKitchenScaleUnit(unit: String): Boolean {
+        throw IllegalArgumentException("Unsupported device type: ${this.lefuDevice?.deviceName}")
+    }
+
+    override suspend fun sendSyncTime(): Boolean {
+        throw IllegalArgumentException("Unsupported device type: ${this.lefuDevice?.deviceName}")
+    }
+
+    override suspend fun switchBuzzer(isOn: Boolean): Boolean {
+        throw IllegalArgumentException("Unsupported device type: ${this.lefuDevice?.deviceName}")
+    }
+
     override suspend fun disconnect() {
         hamburgerController.stopSeach()
         hamburgerController.registDataChangeListener(null)

--- a/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/impl/HamburgerDeviceImpl.kt
+++ b/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/impl/HamburgerDeviceImpl.kt
@@ -12,7 +12,6 @@ import android.util.Log
 import kotlinx.coroutines.*
 
 class HamburgerDeviceImpl : AbstractDevice() {
-
     private val TAG = "LefuScaleService: HamburgerDevice"
     private val timeout = 4_000L
     private var lastWeightReceivedTime = AtomicLong(0L)
@@ -20,8 +19,7 @@ class HamburgerDeviceImpl : AbstractDevice() {
     private var isActive = false
     private var isDisconnected = true
 
-    private val hamburgerController: PPBlutoothPeripheralHamburgerController
-        get() = controller as PPBlutoothPeripheralHamburgerController
+    private val hamburgerController = PPBlutoothPeripheralHamburgerController()
 
     private val dataChangeListener = object : FoodScaleDataChangeListener() {
         override fun processData(foodScaleGeneral: LFFoodScaleGeneral?, deviceModel: PPDeviceModel) {
@@ -47,67 +45,18 @@ class HamburgerDeviceImpl : AbstractDevice() {
         }
     }
 
-    init {
-        controller = PPBlutoothPeripheralHamburgerController()
-    }
-
-    /**
-     * Attempts to connect to the device by starting a BLE scan.
-     * Note: The actual connection is asynchronous. This method initiates the process.
-     * @return `true` if the scan was started successfully, `false` otherwise.
-     */
-    override fun connect(): Boolean {
-        Log.d(TAG, "Connecting to lefuscale ${lefuDevice!!.deviceMac}")
-        lefuDevice!!.let {
-            hamburgerController.startSearch(it.deviceMac, this.bleStateInterface)
-        }
-        this.isActive = true
-        return true
-    }
-
-    /**
-     * Registers a listener for Bluetooth state changes.
-     * The listener will be notified of connection status, etc.
-     */
-    override fun addBleStatusListener(listener: PPBleStateInterface) {
-        this.bleStateInterface = listener
-    }
-
-    /**
-     * Registers a listener for data received from the food scale.
-     */
-    override fun startDataListener() {
-        hamburgerController.registDataChangeListener(dataChangeListener)
-    }
-
-    /**
-     * Unregister listener to receive data from the device.
-     */
-    override fun removeDataListener() {
-        hamburgerController.registDataChangeListener(null)
-    }
-
-    /**
-     * Gets the current connection status from the SDK.
-     * @return A string representing the current device status.
-     */
-    override fun getDeviceStatus(): Boolean {
-        
-        return true
-    }
-
     /** 
      * Function will execute on a background thread checking the 
      * last update from lefuScale after the defined timeout and if scale is connected
      */ 
-    override fun autoReconnect() {
+    private fun autoReconnect() {
         this.disconnectMonitorJob?.cancel()
         this.disconnectMonitorJob = CoroutineScope(Dispatchers.Default).launch {
             while (this@HamburgerDeviceImpl.isActive) {
                 val elapsed = System.currentTimeMillis() - lastWeightReceivedTime.get()
                 if (elapsed > timeout) {
                     Log.d(TAG, "Doing routine check after $elapsed ms.")
-                    connect()
+                    connect(this@HamburgerDeviceImpl.lefuDevice!!)
                     if (isDisconnected){
                         onBroadcastReceived!!.invoke("CustomPPBWorkSearchNotFound")
                     }
@@ -117,13 +66,37 @@ class HamburgerDeviceImpl : AbstractDevice() {
             }
         }
     }
-    
 
-    override fun disconnect() {
-        this.isActive = false
-        this.lefuDevice = null
-        lastWeightReceivedTime = AtomicLong(0L)
+    override fun setup(device: PPDeviceModel) {
+        this.lefuDevice = device
+        hamburgerController.registDataChangeListener(dataChangeListener)
+    }
+
+    /**
+     * Attempts to connect to the device by starting a BLE scan.
+     * Note: The actual connection is asynchronous. This method initiates the process.
+     * @return `true` if the scan was started successfully, `false` otherwise.
+     */
+    override fun connect(device: PPDeviceModel): Boolean {
+        Log.d(TAG, "Connecting to lefuscale ${device.deviceMac}")
+        hamburgerController.startSearch(device.deviceMac, null)
+        if (disconnectMonitorJob == null) { 
+            // Assumes that is it connected as there is no stable connected state for hamburger
+            this@HamburgerDeviceImpl.isActive = true
+            autoReconnect() 
+        }
+
+        return true
+    }
+
+    override suspend fun disconnect() {
+        hamburgerController.stopSeach()
         hamburgerController.registDataChangeListener(null)
         hamburgerController.disConnect()
+        this.isActive = false
+        disconnectMonitorJob?.cancel()
+        disconnectMonitorJob = null
+        lastWeightReceivedTime = AtomicLong(0L)
+        this.lefuDevice = null
     }
 }

--- a/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/impl/HamburgerDeviceImpl.kt
+++ b/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/impl/HamburgerDeviceImpl.kt
@@ -56,7 +56,9 @@ class HamburgerDeviceImpl : AbstractDevice() {
                 val elapsed = System.currentTimeMillis() - lastWeightReceivedTime.get()
                 if (elapsed > timeout) {
                     Log.d(TAG, "Doing routine check after $elapsed ms.")
-                    connect(this@HamburgerDeviceImpl.lefuDevice!!)
+                    if (this@HamburgerDeviceImpl.lefuDevice != null) {
+                        connect(this@HamburgerDeviceImpl.lefuDevice!!)
+                    } 
                     if (isDisconnected){
                         onBroadcastReceived!!.invoke("CustomPPBWorkSearchNotFound")
                     }

--- a/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/utils/FoodScaleUnit.kt
+++ b/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/utils/FoodScaleUnit.kt
@@ -1,9 +1,12 @@
 package expo.modules.lefuscale.device.utils
 
+import com.lefu.ppbase.vo.PPUnitType; 
+
 enum class FoodScaleUnit(val rawValue: String, val displayName: String) {
     GRAMS("ppunitg", "grams"),
     KILOGRAMS("ppunitkg", "kg"),
     MILLILITERS_WATER("ppunitmlwater", "ml"),
+    MILLILITERS_MILK("ppunitmlmilk", "ml milk"),
     OUNCES("ppunitoz", "oz"),
     POUNDS("unit_lb", "lb"),
     OUNCESPOUNDS("ppunitlboz", "lb oz"),
@@ -12,6 +15,38 @@ enum class FoodScaleUnit(val rawValue: String, val displayName: String) {
     companion object {
         fun fromRawValue(value: String?): FoodScaleUnit {
             return values().find { it.rawValue.equals(value, ignoreCase = true) } ?: UNKNOWN
+        }
+
+        /**
+         * Accepts user-friendly input like "g", "kg", "ml", etc.
+         */
+        fun fromUserInput(input: String?): FoodScaleUnit {
+            return when (input?.lowercase()) {
+                "g", "gram", "grams" -> GRAMS
+                "kg", "kilogram", "kilograms" -> KILOGRAMS
+                "ml" -> MILLILITERS_WATER
+                "milk" -> MILLILITERS_MILK
+                "oz", "ounces" -> OUNCES
+                "lb", "pounds" -> POUNDS
+                "lb oz", "pounds ounces", "lboz" -> OUNCESPOUNDS
+                else -> UNKNOWN
+            }
+        }
+    }
+
+    /**
+     * Converts this FoodScaleUnit to PPUnitType used by the SDK.
+     */
+    fun toPPUnitType(): PPUnitType? {
+        return when (this) {
+            GRAMS -> PPUnitType.PPUnitG
+            KILOGRAMS -> PPUnitType.Unit_KG
+            MILLILITERS_WATER -> PPUnitType.PPUnitMLWater
+            MILLILITERS_MILK -> PPUnitType.PPUnitMLMilk
+            OUNCES -> PPUnitType.PPUnitOZ
+            POUNDS -> PPUnitType.Unit_LB
+            OUNCESPOUNDS -> PPUnitType.PPUnitLBOZ
+            UNKNOWN -> null
         }
     }
 }

--- a/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/utils/ScaleResultCallback.kt
+++ b/modules/lefu-scale/android/src/main/java/expo/modules/lefuscale/device/utils/ScaleResultCallback.kt
@@ -1,0 +1,40 @@
+import android.util.Log
+import com.peng.ppscale.business.ble.listener.PPBleSendResultCallBack
+import com.peng.ppscale.vo.PPScaleSendState
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+suspend fun awaitScaleResultCallback(
+    text: String,
+    tag: String = "LefuScaleService",
+    callWithCallback: (PPBleSendResultCallBack) -> Unit
+): Boolean = suspendCancellableCoroutine { cont ->
+    val callback = object : PPBleSendResultCallBack {
+        override fun onResult(state: PPScaleSendState?) {
+            when (state) {
+                PPScaleSendState.PP_SEND_SUCCESS -> {
+                    Log.d(tag, "$text success")
+                    cont.resume(true)
+                }
+                PPScaleSendState.PP_SEND_FAIL -> {
+                    Log.e(tag, "$text failed")
+                    cont.resume(false)
+                }
+                PPScaleSendState.PP_DEVICE_NO_CONNECT -> {
+                    Log.e(tag, "$text device not connected")
+                    cont.resume(false)
+                }
+                PPScaleSendState.PP_DEVICE_ERROR -> {
+                    Log.e(tag, "$text device error")
+                    cont.resume(false)
+                }
+                else -> {
+                    Log.e(tag, "$text unknown state")
+                    cont.resume(false)
+                }
+            }
+        }
+    }
+
+    callWithCallback(callback)
+}

--- a/modules/lefu-scale/src/LefuScaleModule.ts
+++ b/modules/lefu-scale/src/LefuScaleModule.ts
@@ -6,7 +6,11 @@ declare class LefuScaleModule extends NativeModule<LefuScaleModuleEvents> {
 	startScan(): Promise<void>
 	stopScan(): Promise<void>
 	connectToDevice(mac: string): Promise<Boolean>
-	disconnect(): Promise<void>
+	disconnect(): Promise<Boolean>
+	toZeroKitchenScale(): Promise<Boolean>
+	changeKitchenScaleUnit(unit: string): Promise<Boolean>
+	sendSyncTime(): Promise<Boolean>
+	switchBuzzer(isOn: string): Promise<Boolean>
 }
 
 export default requireNativeModule<LefuScaleModule>('LefuScale')

--- a/modules/lefu-scale/src/LefuScaleModule.ts
+++ b/modules/lefu-scale/src/LefuScaleModule.ts
@@ -5,7 +5,7 @@ declare class LefuScaleModule extends NativeModule<LefuScaleModuleEvents> {
 	initializeSdk(apiKey: string, apiSecret: string): Promise<void>
 	startScan(): Promise<void>
 	stopScan(): Promise<void>
-	connectToDevice(mac: string): Promise<void>
+	connectToDevice(mac: string): Promise<Boolean>
 	disconnect(): Promise<void>
 }
 

--- a/src/components/ScaleConnectButton.js
+++ b/src/components/ScaleConnectButton.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
 import { Button } from 'react-native-paper'
 
@@ -7,8 +7,7 @@ import ScaleServiceFactory from '../services/ScaleServiceFactory'
 const ScaleConnectButton = ({ onConnect, onDisconnect }) => {
 	const [isConnected, setIsConnected] = useState(false)
 	const [error, setError] = useState(null)
-	const isConnectingRef = useRef(false)
-	const [, forceUpdate] = useState({})
+	const [isConnecting, setIsConnecting] = useState(false)
 
 	// Check connection status periodically
 	useEffect(() => {
@@ -19,13 +18,11 @@ const ScaleConnectButton = ({ onConnect, onDisconnect }) => {
 
 			// If connection state changed, update isConnectingRef
 			if (wasConnected !== status.isConnected) {
-				isConnectingRef.current = true
-				forceUpdate({})
+				setIsConnecting(true)
 
 				// Set a timeout to reset isConnectingRef after a short delay
 				setTimeout(() => {
-					isConnectingRef.current = false
-					forceUpdate({})
+					setIsConnecting(false)
 				}, 1000)
 			}
 		}
@@ -40,8 +37,7 @@ const ScaleConnectButton = ({ onConnect, onDisconnect }) => {
 
 	const handlePress = async () => {
 		try {
-			isConnectingRef.current = true
-			forceUpdate({})
+			setIsConnecting(true)
 			setError(null)
 			if (isConnected) {
 				await ScaleServiceFactory.disconnectFromScale()
@@ -51,14 +47,13 @@ const ScaleConnectButton = ({ onConnect, onDisconnect }) => {
 				if (onConnect) onConnect()
 			}
 		} catch (error) {
-			isConnectingRef.current = false
-			forceUpdate({})
+			setIsConnecting(false)
 			setError(error.message)
 		}
 	}
 
 	const getButtonContent = () => {
-		if (isConnectingRef.current) {
+		if (isConnecting) {
 			return (
 				<View style={styles.loadingContainer}>
 					<ActivityIndicator color="#fff" style={styles.spinner} />
@@ -77,7 +72,7 @@ const ScaleConnectButton = ({ onConnect, onDisconnect }) => {
 			<Button
 				mode="contained"
 				onPress={handlePress}
-				disabled={isConnectingRef.current}
+				disabled={isConnecting}
 				buttonColor={isConnected ? '#f44336' : '#2196F3'}
 				style={styles.button}
 			>

--- a/src/modules/bluetooth/LefuScaleModule.js
+++ b/src/modules/bluetooth/LefuScaleModule.js
@@ -4,6 +4,7 @@ export const LefuScaleEvents = Object.freeze({
 	ON_DEVICE_DISCOVERED: 'onDeviceDiscovered',
 	ON_BLE_STATE_CHANGE: 'onBleStateChange',
 	ON_WEIGHT_CHANGE: 'onWeightChange',
+	ON_ERROR: 'onConnectError',
 })
 
 class LefuScaleModule {
@@ -47,6 +48,10 @@ class LefuScaleModule {
 
 	addDeviceDiscoveredListener(callback) {
 		return this.#addListener(LefuScaleEvents.ON_DEVICE_DISCOVERED, callback)
+	}
+
+	addErrorListener(callback) {
+		return this.#addListener(LefuScaleEvents.ON_ERROR, callback)
 	}
 
 	addBleStateChangeListener(callback) {

--- a/src/modules/bluetooth/LefuScaleModule.js
+++ b/src/modules/bluetooth/LefuScaleModule.js
@@ -31,6 +31,22 @@ class LefuScaleModule {
 		return this.lefuScale.connectToDevice(deviceId)
 	}
 
+	async toZeroKitchenScale() {
+		return this.lefuScale.toZeroKitchenScale()
+	}
+
+	async changeKitchenScaleUnit(unit) {
+		return this.lefuScale.changeKitchenScaleUnit(unit)
+	}
+
+	async sendSyncTime() {
+		return this.lefuScale.sendSyncTime()
+	}
+
+	async switchBuzzer(isOn) {
+		return this.lefuScale.switchBuzzer(isOn)
+	}
+
 	async disconnect() {
 		return this.lefuScale.disconnect()
 	}

--- a/src/services/BluetoothScaleService.js
+++ b/src/services/BluetoothScaleService.js
@@ -93,7 +93,7 @@ class BluetoothScaleService extends ScaleInterface {
 		this.manager.stopDeviceScan()
 	}
 
-	async connect(deviceId, onWeightUpdate) {
+	async connect(device, onWeightUpdate) {
 		if (this.connectedDevice) {
 			throw new Error('Already connected to a device')
 		}
@@ -105,8 +105,8 @@ class BluetoothScaleService extends ScaleInterface {
 			)
 
 			// Connect with timeout
-			const device = await Promise.race([
-				this.manager.connectToDevice(deviceId, {
+			const connectedDevice = await Promise.race([
+				this.manager.connectToDevice(device.id, {
 					timeout: 5000,
 					autoConnect: true, // Try this if regular connect fails
 				}),
@@ -114,21 +114,21 @@ class BluetoothScaleService extends ScaleInterface {
 			])
 
 			// Wait for service discovery
-			await device.discoverAllServicesAndCharacteristics()
+			await connectedDevice.discoverAllServicesAndCharacteristics()
 
 			// Check connection state
-			const isConnected = await device.isConnected()
+			const isConnected = await connectedDevice.isConnected()
 			console.log('Connected:', isConnected)
 			if (!isConnected) {
 				throw new Error('Device disconnected after connection')
 			}
 
-			this.connectedDevice = device
-			return device
+			this.connectedDevice = connectedDevice
+			return connectedDevice
 		} catch (error) {
 			console.error('Connection error:', error)
 			// Clean up any existing connection
-			await this.manager.cancelDeviceConnection(deviceId).catch(() => null)
+			await this.manager.cancelDeviceConnection(device.id).catch(() => null)
 			throw error
 		}
 	}

--- a/src/services/EtekcityBluetoothService.js
+++ b/src/services/EtekcityBluetoothService.js
@@ -208,19 +208,19 @@ class EtekcityScaleService extends ScaleInterface {
 		}
 	}
 
-	async connect(deviceId, onWeightUpdate) {
-		console.log(`[EtekcityScale] Attempting to connect to device: ${deviceId}`)
+	async connect(device, onWeightUpdate) {
+		console.log(`[EtekcityScale] Attempting to connect to device: ${device.id}`)
 		if (!this.manager) {
 			console.error('[EtekcityScale] No BLE manager available')
 			throw new Error('Bluetooth is not supported on this platform')
 		}
 
 		try {
-			this.device = await this.manager.connectToDevice(deviceId)
+			this.device = await this.manager.connectToDevice(device.id)
 			console.log('[EtekcityScale] Connected to device')
 
 			// Save the device ID upon successful connection
-			await this.saveLastConnectedDeviceId(deviceId)
+			await this.saveLastConnectedDeviceId(device.id)
 
 			console.log('[EtekcityScale] Discovering services and characteristics')
 			await this.device.discoverAllServicesAndCharacteristics()

--- a/src/services/LefuScaleService.js
+++ b/src/services/LefuScaleService.js
@@ -73,7 +73,11 @@ class LefuScaleService extends ScaleInterface {
 		const res = await LefuScaleModule.connectToDevice(device.id)
 
 		if (!res) {
-			throw new Error(`Unable to connect to ${device.id}!`)
+			throw new Error(
+				`Unable to connect to ${
+					device.name || 'unknown device (' + device.id + ')'
+				}!`
+			)
 		}
 
 		// Store the device info
@@ -97,14 +101,6 @@ class LefuScaleService extends ScaleInterface {
 					// TODO: Handle an overlay component to reconnect that will go away after x seconds.
 					// this.handleNotFound()
 					break
-				case 'CustomPPBWorkSearchDeviceDisconnected':
-					console.log(
-						'Successfully device disconnected, removing all listeners'
-					)
-					this.disconnect()
-					LefuScaleModule.removeAllListener()
-					this.isActive = false
-					this.device = null
 			}
 		})
 
@@ -131,7 +127,16 @@ class LefuScaleService extends ScaleInterface {
 	}
 
 	async disconnect() {
-		await LefuScaleModule.disconnect()
+		const res = await LefuScaleModule.disconnect()
+		if (res) {
+			LefuScaleModule.removeAllListener()
+			this.isActive = false
+			this.device = null
+			console.log('Successfully disconnected from scale')
+		} else {
+			console.error('Failed to disconnect from scale')
+		}
+		return res
 	}
 
 	async readWeight(device) {

--- a/src/services/LefuScaleService.js
+++ b/src/services/LefuScaleService.js
@@ -31,18 +31,17 @@ class LefuScaleService extends ScaleInterface {
 			if (onDeviceFound) {
 				onDeviceFound(device)
 					.then(() => {
-						if (device.name) {
-							this.device.name = device.name
-						} else {
-							this.device.name = 'Lefu Kitchen Scale'
-						}
-
 						resolveScanSuccess()
 					})
 					.catch((e) => {
-						rejectScanFailure(e)
+						LefuScaleModule.removeAllListener()
+						rejectScanFailure(new Error(e))
 					})
 			}
+		})
+
+		LefuScaleModule.addErrorListener((e) => {
+			console.log('LefuScale Error received: ', e.errorMessage)
 		})
 
 		// Early BLE failure listeners
@@ -53,7 +52,7 @@ class LefuScaleService extends ScaleInterface {
 				case 'PPBleWorkStateConnectFailed':
 				case 'PPBleDiscoverServiceFail':
 				case 'PPBleWorkStateAuthFailed':
-					LefuScaleModule.removeListener([LefuScaleEvents.ON_BLE_STATE_CHANGE])
+					LefuScaleModule.removeAllListener()
 					rejectScanFailure(
 						new Error(`BLE connection failed with state: ${event.state}`)
 					)
@@ -70,12 +69,17 @@ class LefuScaleService extends ScaleInterface {
 		LefuScaleModule.removeListener([LefuScaleEvents.ON_DEVICE_DISCOVERED])
 	}
 
-	async connect(deviceId, onWeightUpdate) {
-		await LefuScaleModule.connectToDevice(deviceId)
+	async connect(device, onWeightUpdate) {
+		const res = await LefuScaleModule.connectToDevice(device.id)
+
+		if (!res) {
+			throw new Error(`Unable to connect to ${device.id}!`)
+		}
+
 		// Store the device info
 		this.device = {
-			id: deviceId,
-			name: 'Lefu Kitchen Scale', // Default fallback name
+			id: device.id,
+			name: device.name || 'Lefu Kitchen Scale', // Default fallback name
 		}
 
 		// Refresh all LefuModule listeners
@@ -97,6 +101,7 @@ class LefuScaleService extends ScaleInterface {
 					console.log(
 						'Successfully device disconnected, removing all listeners'
 					)
+					this.disconnect()
 					LefuScaleModule.removeAllListener()
 					this.isActive = false
 					this.device = null
@@ -113,6 +118,10 @@ class LefuScaleService extends ScaleInterface {
 					isTare: data.isTare || false,
 				})
 			}
+		})
+
+		LefuScaleModule.addErrorListener((e) => {
+			console.log('LefuScale Error received: ', e.errorMessage)
 		})
 
 		// Set isActive to true to prevent disconnection

--- a/src/services/MockScaleService.js
+++ b/src/services/MockScaleService.js
@@ -34,21 +34,21 @@ class MockScaleService extends ScaleInterface {
 		console.log('Mock scale: Stopping scan...')
 	}
 
-	async connect(deviceId, onWeightUpdate) {
+	async connect(device, onWeightUpdate) {
 		if (this.connectedDevice) {
 			throw new Error('Already connected to a device')
 		}
 
-		console.log('Mock scale: Connecting to device:', deviceId)
+		console.log('Mock scale: Connecting to device:', device.id)
 
 		// Simulate connection delay
 		await new Promise((resolve) => setTimeout(resolve, 1000))
 
 		this.connectedDevice = {
-			id: deviceId,
+			id: device.id,
 			name: 'Mock Scale',
 		}
-		this.deviceId = deviceId
+		this.deviceId = device.id
 		// Start sending random weight updates
 		this.startWeightUpdates(onWeightUpdate)
 

--- a/src/services/ScaleInterface.js
+++ b/src/services/ScaleInterface.js
@@ -3,44 +3,44 @@
  * Any scale implementation must implement these methods
  */
 export class ScaleInterface {
-  /**
-   * Start scanning for scale devices
-   * @param {Function} onDeviceFound - Callback when a device is found
-   */
-  startScan(onDeviceFound) {
-    throw new Error('startScan must be implemented');
-  }
+	/**
+	 * Start scanning for scale devices
+	 * @param {Function} onDeviceFound - Callback when a device is found
+	 */
+	startScan(onDeviceFound) {
+		throw new Error('startScan must be implemented')
+	}
 
-  /**
-   * Stop scanning for devices
-   */
-  stopScan() {
-    throw new Error('stopScan must be implemented');
-  }
+	/**
+	 * Stop scanning for devices
+	 */
+	stopScan() {
+		throw new Error('stopScan must be implemented')
+	}
 
-  /**
-   * Connect to a specific device
-   * @param {string} deviceId - The ID of the device to connect to
-   * @param {Function} onWeightUpdate - Callback for weight updates
-   * @returns {Promise<Object>} The connected device object
-   */
-  connect(deviceId) {
-    throw new Error('connect must be implemented');
-  }
+	/**
+	 * Connect to a specific device
+	 * @param {{name: string, id: string}} device - The ID and Name of the device to connect to
+	 * @param {Function} onWeightUpdate - Callback for weight updates
+	 * @returns {Promise<Object>} The connected device object
+	 */
+	connect(device) {
+		throw new Error('connect must be implemented')
+	}
 
-  /**
-   * Disconnect from a specific device
-   */
-  disconnect() {
-    throw new Error('disconnect must be implemented');
-  }
+	/**
+	 * Disconnect from a specific device
+	 */
+	disconnect() {
+		throw new Error('disconnect must be implemented')
+	}
 
-  /**
-   * Read the current weight from the device
-   * @param {Object} device - The connected device object
-   * @returns {Promise<number>} The current weight reading
-   */
-  readWeight(device) {
-    throw new Error('readWeight must be implemented');
-  }
-} 
+	/**
+	 * Read the current weight from the device
+	 * @param {Object} device - The connected device object
+	 * @returns {Promise<number>} The current weight reading
+	 */
+	readWeight(device) {
+		throw new Error('readWeight must be implemented')
+	}
+}


### PR DESCRIPTION
Successfully implemented LefuScale Fish Peripheral type

**New functionalities:**
- setup(device: PPDeviceModel) - listeners
- connect(device: PPDeviceModel) - device
- disconnect() - device
- autoReconnect() - device
- toZeroKitchenScale() - taring device
- changeKitchenScaleUnit(unit: String) - Change device units ( Grams, ounces, millimetre water, millimetre milk)
- sendSyncTime() - sync local time to device
- switchBuzzer(isOn: Boolean) - Sets device sound on/off

**Patches:**
- Fix on handling of false connection errors

**Updates:**
- connect() function takes in type device { name: string, id: string } instead of type { deviceId: string } to allow ease and property passing of device object
- New onError LefuScale event listener

**Observations**
- Fish Peripheral weighing scale will power down/turn off after 2mins 15sec of last update/change.
- SDK will only detect disconnect/off state after 30s of actual disconnect.
- Weight changes are very sensitive and instantaneous.
- Example
  - 16:14:45 - device sends last weight update
  - 16:17:00 - device turns off (after 2min 15s)
  - 16:17:31 - Broadcast workstate updates to disconnected (after 30s)